### PR TITLE
Added back check for null cursor 

### DIFF
--- a/postscribe.js
+++ b/postscribe.js
@@ -17,7 +17,7 @@
   var DEBUG = true;
 
   // Turn on to debug how each chunk affected the DOM.
-  var DEBUG_CHUNK = true;
+  var DEBUG_CHUNK = false;
 
   // # Helper Functions
 


### PR DESCRIPTION
When the script to inject to the page has an IFRAME with an SCRIPT tag embedded on it the check for the cursor is in fact needed. The check was removed recently but I think it should be kept. 

I realize there are still issues with the IFRAME with the embedded SCRIPT but the check prevents the code from throwing an exception. More on this in future pull requests (hopefully)
