### PR TITLE
Move PhantomJS to package.json, fix repository field, and update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ We ♥  [forks and pull requests](https://help.github.com/articles/using-pull-re
 To run the tests and static code analysis tools, you will need to have the following installed:
 
 * nodejs (>=0.8) & npm - [Install Instructions](https://github.com/joyent/node/wiki/Installation)
-* PhantomJS - A headless browser based on Webkit. [Install Instructions](http://phantomjs.org/download.html)
 * All other project dependencies are installed via npm with `npm install`
 	* [grunt](http://gruntjs.com) - a 'make' like tool for automating build, test, and other dev tasks
+	* [PhantomJS](http://phantomjs.org/) - A headless browser based on Webkit.
 
 ## Pull Request Guidelines
 Spaces, not tabs. 2 of them. [jQuery's style guide](http://docs.jquery.com/JQuery_Core_Style_Guidelines) covers just about everything else.

--- a/package.json
+++ b/package.json
@@ -30,15 +30,16 @@
     "type": "MIT",
     "url": "https://github.com/krux/postscribe/blob/master/LICENSE"
   }],
-  "repositories": [{
+  "repository": {
     "type": "git",
     "url": "git@github.com:krux/postscribe.git"
-  }],
+  },
   "dependencies": {},
   "devDependencies": {
+    "browserstack-cli": "0.x.x",
     "grunt": "0.3.x",
-    "testem": "0.2.x",
-    "browserstack-cli": "0.x.x"
+    "phantomjs": "~1.9",
+    "testem": "0.2.x"
   },
   "homepage": "https://github.com/krux/postscribe",
   "engines": {


### PR DESCRIPTION
Makes setup as simple as having npm and doing `npm install`.

Additionally, I got a warning from npm that repositories should instead be repository (see: https://npmjs.org/doc/json.html#repository).
