### PR TITLE
Fixed issue: cleanup() function not call in onerror handler.

### DIFF
--- a/postscribe.js
+++ b/postscribe.js
@@ -448,8 +448,8 @@
         },
 
         onerror: function() {
-          error({ message: 'remote script failed ' + el.src });
           cleanup();
+          error({ message: 'remote script failed ' + el.src });
         }
       });
     };


### PR DESCRIPTION
Calling error() function raise exception and prevent cleanup() calling.
