### PR TITLE
New hook for handling tokens before they are written

### DIFF
--- a/htmlParser/htmlParser.js
+++ b/htmlParser/htmlParser.js
@@ -364,8 +364,9 @@
             str += '="'+(val ? val.replace(/(^|[^\\])"/g, '$1\\\"') : '')+'"';
           }
         }
-        if (tok.rest)
+        if (tok.rest) {
           str += tok.rest;
+        }
         return str + (tok.unary && !tok.html5Unary ? '/>' : '>');
       },
       chars: function(tok) {

--- a/postscribe.js
+++ b/postscribe.js
@@ -21,7 +21,7 @@
     // Called immediately before adding to the write queue.
     beforeEnqueue: doNothing,
     // Called before writing a token.
-    beforeTokenWrite: function(tok) { return tok; },
+    beforeWriteToken: function(tok) { return tok; },
     // Called before writing buffered document.write calls.
     beforeWrite: function(str) { return str; },
     // Called when evaluation is finished.
@@ -224,7 +224,7 @@
 
       // stop if we see a script token
       while((tok = this.parser.readToken()) && !(script=isScript(tok)) && !(style=isStyle(tok))) {
-        tok = this.options.beforeTokenWrite(tok);
+        tok = this.options.beforeWriteToken(tok);
 
         if (tok) {
           tokens.push(tok);
@@ -367,7 +367,7 @@
       //noinspection JSUnresolvedVariable
       tok.src = tok.attrs.src || tok.attrs.SRC;
 
-      tok = this.options.beforeTokenWrite(tok);
+      tok = this.options.beforeWriteToken(tok);
 
       if(!tok) {
         // User has removed this token
@@ -402,7 +402,7 @@
 
       tok.type = tok.attrs.type || tok.attrs.TYPE || 'text/css';
 
-      tok = this.options.beforeTokenWrite(tok);
+      tok = this.options.beforeWriteToken(tok);
 
       if(tok) {
         // Put the style node in the DOM.

--- a/test/test.js
+++ b/test/test.js
@@ -657,7 +657,7 @@ $(document).ready(function() {
   module('token processing');
   setOptions({});
 
-  testBeforeTokenWriteCalled = function(name, html, type, expectedAmount) {
+  testBeforeWriteTokenCalled = function(name, html, type, expectedAmount) {
     test(name, function() {
       var amount = 0;
       var div = document.createElement('div');
@@ -665,7 +665,7 @@ $(document).ready(function() {
       document.body.appendChild(div);
       stop();
       postscribe(div, html, {
-        beforeTokenWrite: function(tok) {
+        beforeWriteToken: function(tok) {
           if (tok.tagName === type && tok.type !== 'endTag') {
             amount++;
           }
@@ -679,10 +679,10 @@ $(document).ready(function() {
     });
   };
 
-  testBeforeTokenWriteCalled('beforeTokenWrite is called for div', '<div>Test</div>', 'div', 1);
-  testBeforeTokenWriteCalled('beforeTokenWrite is called for script', '<script>document.write("A");</script>', 'script', 1);
-  testBeforeTokenWriteCalled('beforeTokenWrite is called for style', '<style>#test { }</style>', 'style', 1);
-  testBeforeTokenWriteCalled('beforeTokenWrite is called for nested scripts', '<script src="remote/write-inline-script.js"></script>', 'script', 2);
+  testBeforeWriteTokenCalled('beforeWriteToken is called for div', '<div>Test</div>', 'div', 1);
+  testBeforeWriteTokenCalled('beforeWriteToken is called for script', '<script>document.write("A");</script>', 'script', 1);
+  testBeforeWriteTokenCalled('beforeWriteToken is called for style', '<style>#test { }</style>', 'style', 1);
+  testBeforeWriteTokenCalled('beforeWriteToken is called for nested scripts', '<script src="remote/write-inline-script.js"></script>', 'script', 2);
 
   test('alter script src', function() {
     var div = document.createElement('div');
@@ -690,14 +690,14 @@ $(document).ready(function() {
     document.body.appendChild(div);
     stop();
     postscribe(div, '<script src="remote/write-inline-script.js"></script>', {
-      beforeTokenWrite: function(tok) {
+      beforeWriteToken: function(tok) {
         if (tok.tagName && tok.tagName === 'script') {
           tok.src = tok.src.replace('write-inline-script.js', 'write-div.js');
         }
         return tok;
       },
       done: function() {
-        ok(div.firstChild.src && div.firstChild.src.indexOf('write-div.js') > -1);
+        ok(div.firstChild.src.indexOf('write-div.js') > -1);
         start();
       }
     });
@@ -709,14 +709,14 @@ $(document).ready(function() {
     document.body.appendChild(div);
     stop();
     postscribe(div, '<img src="https://lorempixel.com/100/80/sports/" alt="">', {
-      beforeTokenWrite: function(tok) {
+      beforeWriteToken: function(tok) {
         if (tok.tagName && tok.tagName === 'img' && tok.attrs && tok.attrs.src) {
           tok.attrs.src = tok.attrs.src.replace('https://', 'http://');
         }
         return tok;
       },
       done: function() {
-        ok(div.firstChild.src && div.firstChild.src.indexOf('http://') === 0);
+        ok(div.firstChild.src.indexOf('http://') === 0);
         start();
       }
     });
@@ -733,7 +733,7 @@ $(document).ready(function() {
       '<script src="remote/write-remote-and-inline-script.js"></script>' +
       '<script src="http://domain2.com/example2.js"></script>', 
       {
-        beforeTokenWrite: function(tok) {
+        beforeWriteToken: function(tok) {
           if (tok.tagName && tok.tagName === 'script') {
             if (tok.src && tok.src.indexOf('http:') === 0) {
               return null;
@@ -761,7 +761,7 @@ $(document).ready(function() {
       '<style type="text/css">body { background-color: green; }</style>' +
       '<STYLE type="text/css">img { border: 1px solid red; }</STYLE>', 
       {
-        beforeTokenWrite: function(tok) {
+        beforeWriteToken: function(tok) {
           if (tok.tagName && tok.tagName.toLowerCase() === 'style') {
             return null;
           }


### PR DESCRIPTION
Proposed solution to #87.

Example usage:

``` javascript
postscribe('#container', '<scr'+'ipt src="somescript.js"></scr'+'ipt>', {
    beforeTokenWrite : function(tok)
    {
        if (location.protocol !== 'https:' || !tok.tagName)
            return tok;

        if (tok.tagName == 'script' && tok.src && tok.src.indexOf('http:') === 0)
        {
            console.log('leaving script from insecure source unwritten');
            return null;
        }

        return tok;
    }
});
```
