### PR TITLE
comment reader: substring one character too long

### DIFF
--- a/htmlParser/htmlParser.js
+++ b/htmlParser/htmlParser.js
@@ -85,7 +85,7 @@
         var index = stream.indexOf('-->');
         if ( index >= 0 ) {
           return {
-            content: stream.substr(4, index),
+            content: stream.substr(4, index-1),
             length: index + 3
           };
         }


### PR DESCRIPTION
The substring ends with the first character behind the comment.
indexOf and substr are both zero based.
A comment starts with 4 characters and ends with 3 chars.
That's why we have to subtract 1.