### PR TITLE
Handle src attributes differently to all others

### DIFF
--- a/htmlParser/htmlParser.js
+++ b/htmlParser/htmlParser.js
@@ -46,7 +46,17 @@
 
     var stack = [];
 
-    // Cache div element for unescaping html entities
+    var unescapeURLs = function (html) {
+      if ( (typeof html === 'string') && (html.indexOf('&') !== -1) ) {
+        html = html.replace('amp;', '').replace(/(&#\d{1,4};)/gm, function(match){
+            var code = match.substring(2,match.length-1);
+            return String.fromCharCode(code);
+          });
+      }
+      return encodeURI(html);
+    };
+
+     // Cache div element for unescaping html entities
     var el = document.createElement('div');
 
     var unescapeHTMLEntities = function(html) {
@@ -146,7 +156,7 @@
             } else {
               var value = arguments[2] || arguments[3] || arguments[4] ||
                 fillAttr.test(name) && name || '';
-              attrs[name] = unescapeHTMLEntities(value);
+              attrs[name] = (name === 'src') ? unescapeURLs(value) : unescapeHTMLEntities(value);
             }
             rest = rest.replace(match, '');
           });

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ $(document).ready(function() {
     '}</style>' +
     '<div id="test_style">' +
     '<img src="http://lorempixel.com/100/80/sports/"/>' +
+    '<div data-x="a<b"></div>' +
     '</div>');
   });
 
@@ -146,9 +147,19 @@ $(document).ready(function() {
     ctx.write('<SCRIPT TYPE="text/javascript" SRC="remote&#47;write-div.js"></SCRIPT>');
   });
 
+  // HTML Escaped Entities - handle amp escaping on src attributes
+  testWrite('Escaped ampersand in src of remote script', function(ctx) {
+    ctx.write('<script type="text/javascript" src="remote/write-using-query-string.js?k=1&amp;k2=2"></script>');
+  });
+
+  // HTML Escaped Entities - do not convert &para to a paragraph symbol
+  testWrite('&para in querystring not escaped to paragraph symbol ', function(ctx) {
+    ctx.write('<script type="text/javascript" src="remote/write-using-query-string.js?k=1&param=foo"></script>');
+  });
+
   // HTML Escaped Entities check issue #81 fix
   testWrite('Escaped HTML Entity script entity name', function(ctx) {
-    ctx.write('<script type="text/javascript" src="remote/write-using-query-string.js?k=1&amp;k2=2"></script>');
+    ctx.write('<div data-x="a&lt;b"></div>');
   });
 
   // general html entity checking


### PR DESCRIPTION
Fix for #81 was a fix for strings that had already been serialized via outerHTML, but caused unserialized url strings to break.

Specificially for the #81 issue, the user was finding that src values with querystrings were broken as `&` got escaped to `&amp;` by outerHTML from the third-party script.

While the fix for this specific case was to use `innerHTML` and then look at the textContent or innerText, for strings that haven't been already serialized (by outerHTML) `innerHTML` causes sequences like `&para` to get escaped to the paragraph symbol.  If a querystring for a script's src value contains `&param=something` then this sequence gets converted to `¶m=something` and the external script doesn't get all the data it needs - it just breaks.

This PR singles out the src attribute and handles them differently.  The `&#nnnn;` entity replacement is reinstated, `&amp;` gets converted to just `&`, and the string is uri-encoded.  No other conversions should be carried out on URLs.  The `unescapeHTMLEntities` is still in place for other attributes (though I am not sure what would require it).