### PR TITLE
Use CommonJS/Node-friendly global namespace instead of this for window

### DIFF
--- a/htmlParser/htmlParser.js
+++ b/htmlParser/htmlParser.js
@@ -3,11 +3,13 @@
 //TODO(#39)
 /*globals console:false*/
 (function() {
+  var root = typeof global !== 'undefined' ? global : this.window || this.global;
+
   var supports = (function() {
     var supports = {};
 
     var html;
-    var work = this.document.createElement('div');
+    var work = root.document.createElement('div');
 
     html = '<P><I></P></I>';
     work.innerHTML = html;
@@ -357,7 +359,7 @@
         var str = '<'+tok.tagName;
         for (var key in tok.attrs) {
           str += ' '+key;
-          
+
           var val = tok.attrs[key];
           if (typeof tok.booleanAttrs == 'undefined' || typeof tok.booleanAttrs[key] == 'undefined') {
             // escape quotes
@@ -391,5 +393,5 @@
     htmlParser.browserHasFlaw = htmlParser.browserHasFlaw || (!supports[key]) && key;
   }
 
-  this.htmlParser = htmlParser;
+  root.htmlParser = htmlParser;
 })();

--- a/postscribe.js
+++ b/postscribe.js
@@ -34,7 +34,7 @@
     releaseAsync: false
   };
 
-  var global = this;
+  var root = typeof global !== 'undefined' ? global : this.window || this.global;
 
   var UNDEFINED = void 0;
 
@@ -42,7 +42,7 @@
     return thing !== UNDEFINED && thing !== null;
   }
 
-  if(global.postscribe) {
+  if(root.postscribe) {
     return;
   }
 
@@ -592,7 +592,7 @@
   }());
 
   // Public-facing interface and queuing
-  global.postscribe = (function() {
+  root.postscribe = (function() {
     var nextId = 0;
 
     var queue = [];
@@ -679,7 +679,7 @@
 
       el =
         // id selector
-        (/^#/).test(el) ? global.document.getElementById(el.substr(1)) :
+        (/^#/).test(el) ? root.document.getElementById(el.substr(1)) :
         // jquery object. TODO: loop over all elements.
         el.jquery ? el[0] : el;
 


### PR DESCRIPTION
A first stab at getting this to work better with Browserify and other Node-like environments.

We basically stop relying on `this` being the global `window` (as this is the case in browser implementations), and use a variable root that's dependent on the environment: `typeof global !== 'undefined' ? global : this.window || this.global`.

This is how I use postscribe at the moment:

```js
import 'postscribe/htmlParser/htmlParser';
import 'postscribe';

global.postscribe(wrapper, `<script src=${videoSource}></script>`);
```

The next steps would be to make it a [UMD](https://github.com/umdjs/umd) module, instead of attaching it to the global namespace.