### PR TITLE
Keep the original onload and onerror functions from script tags

### DIFF
--- a/postscribe.js
+++ b/postscribe.js
@@ -552,13 +552,17 @@
 
       // Error handler
       var error = this.options.error;
+      var origOnLoad = el.onload || doNothing;
+      var origOnError = el.onerror  || doNothing;
 
       function success() {
+        origOnLoad();
         cleanup();
         done();
       }
 
       function failure(err) {
+        origOnError();
         cleanup();
         error(err);
         done();

--- a/test/scripttest
+++ b/test/scripttest
@@ -1,4 +1,0 @@
-function documentDone(){
-    console.log("done");
-}
-document.write('\x3cscript type="text/javascript" src="mraid.js" onload="documentDone()" onerror="documentDone()"\x3e\x3c/script\x3e');

--- a/test/scripttest
+++ b/test/scripttest
@@ -1,0 +1,4 @@
+function documentDone(){
+    console.log("done");
+}
+document.write('\x3cscript type="text/javascript" src="mraid.js" onload="documentDone()" onerror="documentDone()"\x3e\x3c/script\x3e');

--- a/test/scripttest.js
+++ b/test/scripttest.js
@@ -1,0 +1,4 @@
+function documentDone(){
+    console.log("done");
+}
+document.write('\x3cscript type="text/javascript" src="loadfile.js" onload="documentDone()" onerror="documentDone()"\x3e\x3c/script\x3e');


### PR DESCRIPTION
Fix for #132 

Right now postscribe is creating new onload and onerror events to javascript tags and overwriting if the script was written as `<script src="" onload="function(){}" onerror="function(){}"></script>`