### PR TITLE
Convert HtmlParser to ES6 class

### DIFF
--- a/src/WriteStream.js
+++ b/src/WriteStream.js
@@ -1,4 +1,4 @@
-import htmlParser from './htmlParser';
+import HtmlParser from './htmlParser';
 import * as utils from './utils';
 
 // Turn on to debug how each chunk affected the DOM.
@@ -63,7 +63,7 @@ export default class WriteStream {
 
       doc,
 
-      parser: htmlParser('', {autoFix: options.autoFix}),
+      parser: new HtmlParser('', {autoFix: options.autoFix}),
 
       // Actual elements by id.
       actuals: [root],
@@ -178,7 +178,7 @@ export default class WriteStream {
 
     utils.each(tokens, function(tok) {
 
-      const tokenRaw = htmlParser.tokenToString(tok);
+      const tokenRaw = HtmlParser.tokenToString(tok);
 
       raw.push(tokenRaw);
 

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -141,7 +141,7 @@ const reader = {
   }
 };
 
-function fixedReadTokenFactory(parser, options) {
+function fixedReadTokenFactory(parser, options, readTokenImpl) {
   // Empty Elements - HTML 4.01
   const EMPTY = /^(AREA|BASE|BASEFONT|BR|COL|FRAME|HR|IMG|INPUT|ISINDEX|LINK|META|PARAM|EMBED)$/i;
 
@@ -180,7 +180,7 @@ function fixedReadTokenFactory(parser, options) {
 
   function peekToken() {
     const tmp = parser.stream;
-    const tok = correct(parser._readTokenImpl());
+    const tok = correct(readTokenImpl());
     parser.stream = tmp;
     return tok;
   }
@@ -230,7 +230,7 @@ function fixedReadTokenFactory(parser, options) {
 
   function skipToken() {
     // shift the next token
-    parser._readTokenImpl();
+    readTokenImpl();
     prepareNextToken();
   }
 
@@ -243,7 +243,7 @@ function fixedReadTokenFactory(parser, options) {
 
   return () => {
     prepareNextToken();
-    return correct(parser._readTokenImpl());
+    return correct(readTokenImpl());
   };
 }
 
@@ -261,7 +261,7 @@ export default class HtmlParser {
     }
 
     if (options.fix) {
-      this._fixedReadToken = fixedReadTokenFactory(this, options);
+      this._fixedReadToken = fixedReadTokenFactory(this, options, () => {return this._readTokenImpl();});
     }
   }
 

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -261,7 +261,7 @@ export default class HtmlParser {
     }
 
     if (options.fix) {
-      this._fixedReadToken = fixedReadTokenFactory(this, options, () => {return this._readTokenImpl();});
+      this._fixedReadToken = fixedReadTokenFactory(this, options, () => this._readTokenImpl());
     }
   }
 

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -42,146 +42,253 @@ const endTag = /^<\/([\-A-Za-z0-9_]+)[^>]*>/;
 const attr = /(?:([\-A-Za-z0-9_]+)\s*=\s*(?:(?:"((?:\\.|[^"])*)")|(?:'((?:\\.|[^'])*)')|([^>\s]+)))|(?:([\-A-Za-z0-9_]+)(\s|$)+)/g;
 const fillAttr = /^(checked|compact|declare|defer|disabled|ismap|multiple|nohref|noresize|noshade|nowrap|readonly|selected)$/i;
 
-export default function htmlParser(stream, options) {
-  stream = stream || '';
+// Order of detection matters: detection of one can only
+// succeed if detection of previous didn't
+const detect = {
+  comment: /^<!--/,
+  endTag: /^<\//,
+  atomicTag: /^<\s*(script|style|noscript|iframe|textarea)[\s\/>]/i,
+  startTag: /^</,
+  chars: /^[^<]/
+};
 
-  // Options
-  options = options || {};
-
-  for (let key in supports) {
-    if (supports.hasOwnProperty(key)) {
-      if (options.autoFix) {
-        options[`fix_${key}`] = true; // !supports[key];
-      }
-      options.fix = options.fix || options[`fix_${key}`];
-    }
-  }
-
-  const stack = [];
-
-  function append(str) {
-    stream += str;
-  }
-
-  function prepend(str) {
-    stream = str + stream;
-  }
-
-  // Order of detection matters: detection of one can only
-  // succeed if detection of previous didn't
-  const detect = {
-    comment: /^<!--/,
-    endTag: /^<\//,
-    atomicTag: /^<\s*(script|style|noscript|iframe|textarea)[\s\/>]/i,
-    startTag: /^</,
-    chars: /^[^<]/
-  };
-
-  // Detection has already happened when a reader is called.
-  const reader = {
-    comment: () => {
-      const index = stream.indexOf('-->');
-      if (index >= 0) {
-        return {
-          content: stream.substr(4, index - 1),
-          length: index + 3
-        };
-      }
-    },
-
-    endTag: () => {
-      const match = stream.match(endTag);
-
-      if (match) {
-        return {
-          tagName: match[1],
-          length: match[0].length
-        };
-      }
-    },
-
-    atomicTag: () => {
-      const start = reader.startTag();
-      if (start) {
-        const rest = stream.slice(start.length);
-        // for optimization, we check first just for the end tag
-        if (rest.match(new RegExp('<\/\\s*' + start.tagName + '\\s*>', 'i'))) {
-          // capturing the content is inefficient, so we do it inside the if
-          const match = rest.match(new RegExp('([\\s\\S]*?)<\/\\s*' + start.tagName + '\\s*>', 'i'));
-          if (match) {
-            // good to go
-            return {
-              tagName: start.tagName,
-              attrs: start.attrs,
-              content: match[1],
-              length: match[0].length + start.length
-            };
-          }
-        }
-      }
-    },
-
-    startTag: () => {
-      const endTagIndex = stream.indexOf('>');
-      if (endTagIndex === -1) {
-        return null; // avoid the match statement if there will be no match
-      }
-
-      const match = stream.match(startTag);
-
-      if (match) {
-        const attrs = {};
-        const booleanAttrs = {};
-        let rest = match[2];
-
-        match[2].replace(attr, function(match, name) {
-          if (!(arguments[2] || arguments[3] || arguments[4] || arguments[5])) {
-            attrs[name] = null;
-          } else if (arguments[5]) {
-            attrs[arguments[5]] = '';
-            booleanAttrs[name] = true;
-          } else {
-            attrs[name] = arguments[2] || arguments[3] || arguments[4] ||
-              fillAttr.test(name) && name || '';
-          }
-          rest = rest.replace(match, '');
-        });
-
-        return {
-          tagName: match[1],
-          attrs,
-          booleanAttrs,
-          rest,
-          unary: !!match[3],
-          length: match[0].length
-        };
-      }
-    },
-
-    chars: () => {
-      const index = stream.indexOf('<');
+// Detection has already happened when a reader is called.
+const reader = {
+  comment: stream => {
+    const index = stream.indexOf('-->');
+    if (index >= 0) {
       return {
-        length: index >= 0 ? index : stream.length
+        content: stream.substr(4, index - 1),
+        length: index + 3
       };
     }
+  },
+
+  endTag: stream => {
+    const match = stream.match(endTag);
+
+    if (match) {
+      return {
+        tagName: match[1],
+        length: match[0].length
+      };
+    }
+  },
+
+  atomicTag: stream => {
+    const start = reader.startTag(stream);
+    if (start) {
+      const rest = stream.slice(start.length);
+      // for optimization, we check first just for the end tag
+      if (rest.match(new RegExp('<\/\\s*' + start.tagName + '\\s*>', 'i'))) {
+        // capturing the content is inefficient, so we do it inside the if
+        const match = rest.match(new RegExp('([\\s\\S]*?)<\/\\s*' + start.tagName + '\\s*>', 'i'));
+        if (match) {
+          // good to go
+          return {
+            tagName: start.tagName,
+            attrs: start.attrs,
+            content: match[1],
+            length: match[0].length + start.length
+          };
+        }
+      }
+    }
+  },
+
+  startTag: stream => {
+    const endTagIndex = stream.indexOf('>');
+    if (endTagIndex === -1) {
+      return null; // avoid the match statement if there will be no match
+    }
+
+    const match = stream.match(startTag);
+
+    if (match) {
+      const attrs = {};
+      const booleanAttrs = {};
+      let rest = match[2];
+
+      match[2].replace(attr, function(match, name) {
+        if (!(arguments[2] || arguments[3] || arguments[4] || arguments[5])) {
+          attrs[name] = null;
+        } else if (arguments[5]) {
+          attrs[arguments[5]] = '';
+          booleanAttrs[name] = true;
+        } else {
+          attrs[name] = arguments[2] || arguments[3] || arguments[4] ||
+            fillAttr.test(name) && name || '';
+        }
+        rest = rest.replace(match, '');
+      });
+
+      return {
+        tagName: match[1],
+        attrs,
+        booleanAttrs,
+        rest,
+        unary: !!match[3],
+        length: match[0].length
+      };
+    }
+  },
+
+  chars: stream => {
+    const index = stream.indexOf('<');
+    return {
+      length: index >= 0 ? index : stream.length
+    };
+  }
+};
+
+function fixedReadTokenFactory(parser, options) {
+  // Empty Elements - HTML 4.01
+  const EMPTY = /^(AREA|BASE|BASEFONT|BR|COL|FRAME|HR|IMG|INPUT|ISINDEX|LINK|META|PARAM|EMBED)$/i;
+
+  // Elements that you can| intentionally| leave open
+  // (and which close themselves)
+  const CLOSESELF = /^(COLGROUP|DD|DT|LI|OPTIONS|P|TD|TFOOT|TH|THEAD|TR)$/i;
+
+  const stack = [];
+  stack.last = function() {
+    return this[this.length - 1];
   };
 
-  function readToken() {
+  stack.lastTagNameEq = function(tagName) {
+    const last = this.last();
+    return last && last.tagName &&
+      last.tagName.toUpperCase() === tagName.toUpperCase();
+  };
+
+  stack.containsTagName = function(tagName) {
+    for (let i = 0, tok; (tok = this[i]); i++) {
+      if (tok.tagName === tagName) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  function correct(tok) {
+    if (tok && tok.type === 'startTag') {
+      // unary
+      tok.unary = EMPTY.test(tok.tagName) || tok.unary;
+      tok.html5Unary = !(/\/>$/).test(tok.text);
+    }
+    return tok;
+  }
+
+  function peekToken() {
+    const tmp = parser.stream;
+    const tok = correct(parser._readTokenImpl());
+    parser.stream = tmp;
+    return tok;
+  }
+
+  function closeLast() {
+    const tok = stack.pop();
+
+    // prepend close tag to stream.
+    parser.prepend(`</${tok.tagName}>`);
+  }
+
+  const handlers = {
+    startTag: tok => {
+      const tagName = tok.tagName;
+      // Fix tbody
+      if (tagName.toUpperCase() === 'TR' && stack.lastTagNameEq('TABLE')) {
+        parser.prepend('<TBODY>');
+        prepareNextToken();
+      } else if (options.fix_selfClose && CLOSESELF.test(tagName) &&
+          stack.containsTagName(tagName)) {
+        if (stack.lastTagNameEq(tagName)) {
+          closeLast();
+        } else {
+          parser.prepend('</' + tok.tagName + '>');
+          prepareNextToken();
+        }
+      } else if (!tok.unary) {
+        stack.push(tok);
+      }
+    },
+
+    endTag: tok => {
+      const last = stack.last();
+      if (last) {
+        if (options.fix_tagSoup && !stack.lastTagNameEq(tok.tagName)) {
+          // cleanup tag soup
+          closeLast();
+        } else {
+          stack.pop();
+        }
+      } else if (options.fix_tagSoup) {
+        // cleanup tag soup part 2: skip this token
+        skipToken();
+      }
+    }
+  };
+
+  function skipToken() {
+    // shift the next token
+    parser._readTokenImpl();
+    prepareNextToken();
+  }
+
+  function prepareNextToken() {
+    const tok = peekToken();
+    if (tok && handlers[tok.type]) {
+      handlers[tok.type](tok);
+    }
+  }
+
+  return () => {
+    prepareNextToken();
+    return correct(parser._readTokenImpl());
+  };
+}
+
+export default class HtmlParser {
+  constructor(stream = '', options = {}) {
+    this.stream = stream;
+
+    for (let key in supports) {
+      if (supports.hasOwnProperty(key)) {
+        if (options.autoFix) {
+          options[`fix_${key}`] = true; // !supports[key];
+        }
+        options.fix = options.fix || options[`fix_${key}`];
+      }
+    }
+
+    if (options.fix) {
+      this._fixedReadToken = fixedReadTokenFactory(this, options);
+    }
+  }
+
+  append(str) {
+    this.stream += str;
+  }
+
+  prepend(str) {
+    this.stream = str + this.stream;
+  }
+
+  _readTokenImpl() {
     // Enumerate detects in order
     for (let type in detect) {
-      if (detect[type].test(stream)) {
+      if (detect[type].test(this.stream)) {
         debugLog(`suspected ${type}`);
 
-        const token = reader[type]();
+        const token = reader[type](this.stream);
         if (token) {
           debugLog(`parsed ${type}`, token);
 
           // Type
           token.type = token.type || type;
           // Entire text
-          token.text = stream.substr(0, token.length);
+          token.text = this.stream.substr(0, token.length);
           // Update the stream
-          stream = stream.slice(token.length);
+          this.stream = this.stream.slice(token.length);
 
           return token;
         }
@@ -190,9 +297,17 @@ export default function htmlParser(stream, options) {
     }
   }
 
-  function readTokens(handlers) {
+  readToken() {
+    if (this._fixedReadToken) {
+      return this._fixedReadToken();
+    } else {
+      return this._readTokenImpl();
+    }
+  }
+
+  readTokens(handlers) {
     let tok;
-    while ((tok = readToken())) {
+    while ((tok = this.readToken())) {
       // continue until we get an explicit "false" return
       if (handlers[tok.type] && handlers[tok.type](tok) === false) {
         return;
@@ -200,142 +315,20 @@ export default function htmlParser(stream, options) {
     }
   }
 
-  function clear() {
-    const rest = stream;
-    stream = '';
+  clear() {
+    const rest = this.stream;
+    this.stream = '';
     return rest;
   }
 
-  function rest() {
-    return stream;
+  rest() {
+    return this.stream();
   }
-
-  if (options.fix) {
-    (function() {
-      // Empty Elements - HTML 4.01
-      const EMPTY = /^(AREA|BASE|BASEFONT|BR|COL|FRAME|HR|IMG|INPUT|ISINDEX|LINK|META|PARAM|EMBED)$/i;
-
-      // Elements that you can| intentionally| leave open
-      // (and which close themselves)
-      const CLOSESELF = /^(COLGROUP|DD|DT|LI|OPTIONS|P|TD|TFOOT|TH|THEAD|TR)$/i;
-
-      const stack = [];
-      stack.last = function() {
-        return this[this.length - 1];
-      };
-
-      stack.lastTagNameEq = function(tagName) {
-        const last = this.last();
-        return last && last.tagName &&
-          last.tagName.toUpperCase() === tagName.toUpperCase();
-      };
-
-      stack.containsTagName = function(tagName) {
-        for (let i = 0, tok; (tok = this[i]); i++) {
-          if (tok.tagName === tagName) {
-            return true;
-          }
-        }
-        return false;
-      };
-
-      function correct(tok) {
-        if (tok && tok.type === 'startTag') {
-          // unary
-          tok.unary = EMPTY.test(tok.tagName) || tok.unary;
-          tok.html5Unary = !(/\/>$/).test(tok.text);
-        }
-        return tok;
-      }
-
-      let readTokenImpl = readToken;
-
-      function peekToken() {
-        const tmp = stream;
-        const tok = correct(readTokenImpl());
-        stream = tmp;
-        return tok;
-      }
-
-      function closeLast() {
-        const tok = stack.pop();
-
-        // prepend close tag to stream.
-        prepend(`</${tok.tagName}>`);
-      }
-
-      const handlers = {
-        startTag: tok => {
-          const tagName = tok.tagName;
-          // Fix tbody
-          if (tagName.toUpperCase() === 'TR' && stack.lastTagNameEq('TABLE')) {
-            prepend('<TBODY>');
-            prepareNextToken();
-          } else if (options.fix_selfClose && CLOSESELF.test(tagName) &&
-              stack.containsTagName(tagName)) {
-            if (stack.lastTagNameEq(tagName)) {
-              closeLast();
-            } else {
-              prepend('</' + tok.tagName + '>');
-              prepareNextToken();
-            }
-          } else if (!tok.unary) {
-            stack.push(tok);
-          }
-        },
-
-        endTag: tok => {
-          const last = stack.last();
-          if (last) {
-            if (options.fix_tagSoup && !stack.lastTagNameEq(tok.tagName)) {
-              // cleanup tag soup
-              closeLast();
-            } else {
-              stack.pop();
-            }
-          } else if (options.fix_tagSoup) {
-            // cleanup tag soup part 2: skip this token
-            skipToken();
-          }
-        }
-      };
-
-      function skipToken() {
-        // shift the next token
-        readTokenImpl();
-
-        prepareNextToken();
-      }
-
-      function prepareNextToken() {
-        const tok = peekToken();
-        if (tok && handlers[tok.type]) {
-          handlers[tok.type](tok);
-        }
-      }
-
-      // redefine readToken
-      readToken = () => {
-        prepareNextToken();
-        return correct(readTokenImpl());
-      };
-    }());
-  }
-
-  return {
-    append: append,
-    readToken: readToken,
-    readTokens: readTokens,
-    clear: clear,
-    rest: rest,
-    stack: stack
-  };
-
 }
 
-htmlParser.supports = supports;
+HtmlParser.supports = supports;
 
-htmlParser.tokenToString = tok => {
+HtmlParser.tokenToString = tok => {
   const handler = {
     comment: tok => {
       return `<!--${tok.content}`;
@@ -379,7 +372,7 @@ htmlParser.tokenToString = tok => {
   return handler[tok.type](tok);
 };
 
-htmlParser.escapeAttributes = attrs => {
+HtmlParser.escapeAttributes = attrs => {
   const escapedAttrs = {};
   // escape double-quotes for writing html as a string
 
@@ -394,6 +387,6 @@ htmlParser.escapeAttributes = attrs => {
 
 for (let key in supports) {
   if (supports.hasOwnProperty(key)) {
-    htmlParser.browserHasFlaw = htmlParser.browserHasFlaw || (!supports[key]) && key;
+    HtmlParser.browserHasFlaw = HtmlParser.browserHasFlaw || (!supports[key]) && key;
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
-import htmlParser from './htmlParser';
+import HtmlParser from './htmlParser';
 import postscribe from './postscribe';
 
 export default postscribe;
 
 export {
-    htmlParser,
+    HtmlParser,
     postscribe
 };


### PR DESCRIPTION
I've gone ahead and gave converting HtmlParser to an ES6 class a go. @sethyates mentioned it in https://github.com/krux/postscribe/pull/138#discussion_r59112302 and I got curious enough to try it myself.

Code could look a bit cleaner using [class properties](https://babeljs.io/docs/plugins/transform-class-properties/), but I'm not sure if you want to use stage 1 proposal features just yet. If you do, I can add the transform and clean up a bit more.

All tests still pass without modifications.

Any thoughts?

(I'm also not sure how to sign the CLA at this point, but consider it signed and agreed with.)