### PR TITLE
chore(build): clean out dist and add sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ node_modules/
 npm-*.log
 
 # Generated files
-.idea/
-
 dist/
+build/
+

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ src/**
 test/**
 webpack.config.babel.js
 *.iml
+build/

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -20,6 +20,7 @@ import esdoc from 'gulp-esdoc';
 import path from 'path';
 
 const DIST = 'dist';
+const BUILD = 'build';
 
 const BANNER = [
   '/**',
@@ -75,7 +76,7 @@ function test(configName, failOnError = true, karmaOptions = {}) {
 gulp.task('default', ['clean', 'lint', 'build', 'doc', 'test']);
 
 gulp.task('clean', () => {
-  return del.sync([`${DIST}/**`]);
+  return del.sync([`${DIST}/**`, `${BUILD}/**`]);
 });
 
 gulp.task('build', build(webpackConfig));

--- a/test/karma-base.config.babel.js
+++ b/test/karma-base.config.babel.js
@@ -59,7 +59,9 @@ export default {
 
   singleRun: true,
 
-  webpack: webpackConfig,
+  webpack: Object.assign(webpackConfig, {
+    devtool: 'inline-source-map'
+  }),
 
   webpackMiddleware: {
     noInfo: true

--- a/test/karma-ci.config.babel.js
+++ b/test/karma-ci.config.babel.js
@@ -35,7 +35,7 @@ module.exports = config => {
     reporters: [
       {type: 'text-summary'},
       {type: 'text'},
-      {type: 'lcov', dir: '../build/test-reports/coverage/'}
+      {type: 'lcov'}
     ]
   };
 

--- a/test/karma-ci.config.babel.js
+++ b/test/karma-ci.config.babel.js
@@ -30,12 +30,12 @@ module.exports = config => {
       }
     },
 
-    dir: '../dist/test-reports/coverage/',
+    dir: '../build/test-reports/coverage/',
 
     reporters: [
       {type: 'text-summary'},
       {type: 'text'},
-      {type: 'lcov', dir: '../dist/test-reports/coverage/'}
+      {type: 'lcov', dir: '../build/test-reports/coverage/'}
     ]
   };
 

--- a/test/karma-coverage.config.babel.js
+++ b/test/karma-coverage.config.babel.js
@@ -30,7 +30,7 @@ module.exports = config => {
       }
     },
 
-    dir: 'dist/test-reports/coverage/',
+    dir: 'build/test-reports/coverage/',
 
     reporters: [
       {type: 'text-summary'},

--- a/test/karma-coverage.config.babel.js
+++ b/test/karma-coverage.config.babel.js
@@ -30,8 +30,6 @@ module.exports = config => {
       }
     },
 
-    dir: 'build/test-reports/coverage/',
-
     reporters: [
       {type: 'text-summary'},
       {type: 'text'}

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -26,5 +26,6 @@ export default {
     filename: `${pkg.name}.js`,
     library: 'postscribe',
     libraryTarget: 'umd'
-  }
+  },
+  devtool: 'source-map'
 };


### PR DESCRIPTION
Moving the test-reports out of dist as they're not part of the distribution. Also, adding sourcemaps
for .max.js.