### PR TITLE
test(ci): fix coveralls reporting

### DIFF
--- a/test/karma-ci.config.babel.js
+++ b/test/karma-ci.config.babel.js
@@ -35,7 +35,7 @@ module.exports = config => {
     reporters: [
       {type: 'text-summary'},
       {type: 'text'},
-      {type: 'lcov'}
+      {type: 'lcov', dir: '../build/test-reports/coverage/'}
     ]
   };
 


### PR DESCRIPTION
given the toolset we're using, the `dir` property is required in `lcov` (one of the tools looks for it explicitly and fails silently if not there \o/).