### PR TITLE
chore(coverage): publish coverage to codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,11 @@ engines:
       - javascript
   eslint:
     enabled: true
+    checks:
+      strict:
+        enabled: false
+      keyword-spacing:
+        enabled: false
   fixme:
     enabled: true
 ratings:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,21 +22,22 @@ script:
   fi
 
 after_success:
-  - npm run semantic-release
+- |
+  npm run semantic-release
+  if [ "${TRAVIS_PULL_REQUEST}" != "true" ]; then
+    npm install codeclimate-test-reporter
+    ./node_modules/.bin/codeclimate-test-reporter < build/test-reports/coverage/*/lcov.info
+  fi
 
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
 
 notifications:
-  email:
-    recipients:
-      - joshua.newman@krux.com
-    on_success: [change]
-    on_failure: [always]
+  email: false
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/9520ebd6229614169878
+      - https://webhooks.gitter.im/e/c5ef8c460e0c28b4817e
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
Previously, we were only publishing coverage to coveralls and using codeclimate only for analysis