### PR TITLE
fix(dependencies): upgrading prescribe to fix a bug in script writing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "dist/postscribe.js",
   "browser": "dist/postscribe.js",
   "dependencies": {
-    "prescribe": ">=1.0.8"
+    "prescribe": ">=1.1.1"
   },
   "devDependencies": {
     "babel-core": "6.7.7",


### PR DESCRIPTION
Previously, if a script and its contents were written over several doc.writes it'd write the
contents outside the scripts text node

#172