### PR TITLE
Adding functionality for observing original onload/onerror functions.

### DIFF
--- a/src/write-stream.js
+++ b/src/write-stream.js
@@ -540,9 +540,13 @@ export default class WriteStream {
       el = el.onload = el.onreadystatechange = el.onerror = null;
     }
 
+		function doNothing() {}
     const error = this.options.error;
+		const originalOnLoad = el.onload || doNothing;
+		const originalOnError = el.onerror || doNothing;
 
     function success() {
+			originalOnLoad();
       cleanup();
       if (done != null) {
         done();
@@ -551,6 +555,7 @@ export default class WriteStream {
     }
 
     function failure(err) {
+			originalOnError();
       cleanup();
       error(err);
       if (done != null) {


### PR DESCRIPTION
This was discussed prior to 2.0 version and was closed out when you guys rolled to 2.0.  it wasn't ever solved.  I would love to see this reincorporated into your codebase so I don't have to fork and maintain my own copy!  Thanks!