### PR TITLE
fix(legacy): fixes issue in legacy browsers

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -56,7 +56,7 @@ function build(config) {
     .pipe(stripDebug())
     .pipe(rename({basename: basename, extname: '.js'}))
     .pipe(gulp.dest(DIST))
-    .pipe(uglify())
+    .pipe(uglify({compress: {properties: false}, output: {'quote_keys': true}}))
     .pipe(header(BANNER))
     .pipe(rename({basename: basename, extname: '.min.js'}))
     .pipe(gulp.dest(DIST))

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "main": "dist/postscribe.js",
   "browser": "dist/postscribe.js",
   "dependencies": {
-    "prescribe": ">=1.1.1"
+    "prescribe": ">=1.1.2"
   },
   "devDependencies": {
     "babel-core": "6.18.2",


### PR DESCRIPTION
This ensures `default` is quoted in Objects.