### PR TITLE
Add version tag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Asynchronously write javascript, even with document.write.",
   "homepage": "https://krux.github.io/postscribe",
   "bugs": "https://github.com/krux/postscribe/issues",
+  "version" : "2.0.8",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Without the version-tag, yarn will not accept the dependency.